### PR TITLE
Allow for a custom text file suffix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,4 +4,9 @@ Change log
 Unreleased
 ----------
 
+- ``--prefix`` argument allows you to customize the suffix of the plain text mirror.
+
+0.1.0 (2021-03-18)
+------------------
+
 Initial release.

--- a/README.rst
+++ b/README.rst
@@ -101,3 +101,23 @@ Note that this workflow can only run with private repositories.
 The ``GITHUB_TOKEN`` secret is not available to public forks.
 
 When using this workflow, contributors need to either pull down the plain text file update to their local branch, or be prepared to use a forced push (``git push --force``) because their branch is "behind" the GitHub origin.
+
+Configuration
+=============
+
+This pre-commit hook works out of the box, but does allow for some customization.
+
+Plain text filename suffix
+--------------------------
+
+By default, if the Word file is named ``document.docx``, the plain text mirror file is named ``document.txt``.
+However, you can customize the suffix of the file name by setting a ``--suffix`` command-line option::
+
+   repos:
+     - repo: https://github.com/jsickcodes/pre-commit-docx-plain
+       rev: 0.2.0
+       hooks:
+         - id: docxplain
+           args:
+             - "prefix"
+             - ".extracted.txt"

--- a/src/docxplain/cli.py
+++ b/src/docxplain/cli.py
@@ -10,7 +10,7 @@ def main() -> None:
     """Command-line entrypoint."""
     parser = create_parser()
     args = parser.parse_args()
-    changed = convert_file(args.source)
+    changed = convert_file(args.source, suffix=args.suffix)
     if changed:
         sys.exit(1)
     else:
@@ -20,5 +20,8 @@ def main() -> None:
 def create_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Convert docx to plain text.")
     parser.add_argument("source")
+    parser.add_argument(
+        "--suffix", default=".txt", help="File suffix for plain text file."
+    )
 
     return parser

--- a/src/docxplain/converter.py
+++ b/src/docxplain/converter.py
@@ -8,8 +8,17 @@ import pypandoc
 __all__ = ["convert_file", "get_hash"]
 
 
-def convert_file(filename: str) -> bool:
+def convert_file(filename: str, suffix: str = ".txt") -> bool:
     """Convert the docx file to plaintext.
+
+    Parameters
+    ----------
+    filename : `str`
+        Path of the docx file.
+    suffix : `str`
+        Suffix for the output plain text file, including ``"."`` prefix.
+        Default is ``".txt"``, but a suffix like ``".extracted.txt"``
+        could be useful.
 
     Returns
     -------
@@ -20,7 +29,7 @@ def convert_file(filename: str) -> bool:
     if not docx_path.is_file():
         raise RuntimeError(f"Source file {docx_path} does not exist.")
 
-    plain_path = docx_path.with_suffix(".txt")
+    plain_path = docx_path.with_suffix(suffix)
     if plain_path.is_file():
         exists = True
         initial_hash = get_hash(plain_path)

--- a/tests/converter_test.py
+++ b/tests/converter_test.py
@@ -31,3 +31,14 @@ def test_new(tmp_path: Path) -> None:
     shutil.copytree(repo_data, work_dir)
     docxpath = work_dir.joinpath("test_doc.docx")
     assert convert_file(str(docxpath)) is True
+
+
+def test_suffix(tmp_path: Path) -> None:
+    """Test the case of a custom plain text file suffix."""
+    repo_data = Path(__file__).parent.joinpath("data/new")
+    work_dir = tmp_path / "suffix"
+    shutil.copytree(repo_data, work_dir)
+    docxpath = work_dir.joinpath("test_doc.docx")
+    assert convert_file(str(docxpath), suffix=".extracted.txt") is True
+    plain_path = work_dir.joinpath("test_doc.extracted.txt")
+    assert plain_path.is_file()


### PR DESCRIPTION
The `--suffix` argument, which can be configured through the `.pre-commit-config.yaml` file, allows you to change the suffix of the plain text mirror file from ".txt" to something more useful, such as ".extracted.txt".